### PR TITLE
Make docker image clear optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Where:
 * `$USERNAME` is the username to use to log into the registry using `docker login`
 * `$PASSWORD` is the password to use to log into the registry using `docker login`
 * `$EMAIL` (optional) is the email to use to log into the registry using `docker login`
-
+* `$SKIP_CLEANUP` (optional) skip clearing local docker images after `docker push`. Must be set to 'true' to skip the cleanup.
 
 ## Build from compressed tarball
 
@@ -50,6 +50,7 @@ Where:
 * `$USERNAME` is the username to use to log into the registry using `docker login`
 * `$PASSWORD` is the password to use to log into the registry using `docker login`
 * `$EMAIL` (optional) is the email to use to log into the registry using `docker login`
+* `$SKIP_CLEANUP` (optional) skip clearing local docker images after `docker push`. Must be set to 'true' to skip the cleanup.
 
 
 # Testing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Where:
 * `$USERNAME` is the username to use to log into the registry using `docker login`
 * `$PASSWORD` is the password to use to log into the registry using `docker login`
 * `$EMAIL` (optional) is the email to use to log into the registry using `docker login`
-* `$SKIP_CLEANUP` (optional) skip clearing local docker images after `docker push`. Must be set to 'true' to skip the cleanup.
+* `$SKIP_CLEAN` (optional) skip clearing local docker images after `docker push`. Must be set to 'true' to skip the cleanup.
 
 ## Build from compressed tarball
 
@@ -50,7 +50,7 @@ Where:
 * `$USERNAME` is the username to use to log into the registry using `docker login`
 * `$PASSWORD` is the password to use to log into the registry using `docker login`
 * `$EMAIL` (optional) is the email to use to log into the registry using `docker login`
-* `$SKIP_CLEANUP` (optional) skip clearing local docker images after `docker push`. Must be set to 'true' to skip the cleanup.
+* `$SKIP_CLEAN` (optional) skip clearing local docker images after `docker push`. Must be set to 'true' to skip the cleanup.
 
 
 # Testing

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,11 @@ if [ ! -z "$IMAGE_NAME" ]; then
 	if [ ! -z "$USERNAME" ] || [ ! -z "$DOCKERCFG" ] || [ -f /.dockercfg ]; then
 		echo "=>  Pushing image $IMAGE_NAME"
 		docker push $IMAGE_NAME
-		docker rmi -f $(docker images -q --no-trunc -a) > /dev/null 2>&1
+		if [ "$SKIP_CLEAN" != "true" ]; then
+			echo "=> Clearing images"
+			docker rmi -f $(docker images -q --no-trunc -a) > /dev/null 2>&1
+			exit 0
+		fi
 	fi
 else
 	echo "   WARNING: no \$IMAGE_NAME found - skipping build and push"

--- a/build.sh
+++ b/build.sh
@@ -86,8 +86,7 @@ if [ ! -z "$IMAGE_NAME" ]; then
 		docker push $IMAGE_NAME
 		if [ "$SKIP_CLEAN" != "true" ]; then
 			echo "=> Clearing images"
-			docker rmi -f $(docker images -q --no-trunc -a) > /dev/null 2>&1
-			exit 0
+		  docker rmi $IMAGE_NAME > /dev/null 2>&1 || (echo "   WARNING: Failed to delete image")
 		fi
 	fi
 else


### PR DESCRIPTION
We made the docker image clear optional, since we're using docker through the sock and would like to maintain the cache for future builds. We also added an exit 0 after the docker rmi statement at the end because its exit code was being used as the exit code of the entire script, which was affecting one of our builds.
