### PR TITLE
Add support for SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ And then run your builds as above appending `--volumes-from builder_cache` to th
 
 If your tests depend on private images, you can pass their credentials either by mounting your local `.dockercfg` file inside the container appending `-v $HOME/.dockercfg:/.dockercfg:r`, or by providing the contents of this file via an environment variable called `$DOCKERCFG`: `-e DOCKERCFG=$(cat $HOME/.dockercfg)`
 
+## SSH credentials and private repos
+
+If you're trying to deploy a private repository that needs SSH keys, mount your key into `/keys/id_rsa`. For GitHub repositories, you can add deploy keys from a project's settings page under "Deploy Keys".
+
+	 docker run -v /path/to/deploykey:/keys/id_rsa -e GIT_REPO=git@github.com:private/repo.git -e GIT_TAG=master ...
+
 ## Using the host docker daemon instead of docker-in-docker
 
 If you want to use the host docker daemon instead of letting the container run its own, mount the host's docker unix socket inside the container by appending `-v /var/run/docker.sock:/var/run/docker.sock:rw` to the `docker run` command.

--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,14 @@ else
 	echo "   WARNING: no \$USERNAME/\$PASSWORD or \$DOCKERCFG found - unable to load any credentials for pushing/pulling"
 fi
 
+if [ -f /keys/id_rsa ]; then
+	echo "=> Using key from /keys/id_rsa"
+	eval `ssh-agent -s`
+	cp /keys/id_rsa /root/id_rsa
+	chmod 400 /root/id_rsa
+	ssh-add /root/id_rsa
+fi
+
 rm -fr /src && mkdir -p /src
 echo "=> Detecting application"
 if [ ! -d /app ]; then


### PR DESCRIPTION
This allows you to deploy private GitHub repositories: #11.

```
docker run \
  -v (pwd)/id_rsa:/keys/id_rsa \
  -e GIT_REPO=git@github.com:private/repo.git \
  -it --rm --privileged tutum/builder ...
```
