### PR TITLE
fix the incorrect exit caluse

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ if [ -S /var/run/docker.sock ]; then
 			curl -o /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}
 		fi
 	fi
-	docker version > /dev/null 2>&1 || (echo "   Failed to connect to docker daemon at /var/run/docker.sock" && exit 1)
+	docker version > /dev/null 2>&1 || { echo "   Failed to connect to docker daemon at /var/run/docker.sock" && exit 1; }
 	EXTERNAL_DOCKER=yes
 else
 	if [ "$(ls -A /var/lib/docker)" ]; then
@@ -38,7 +38,7 @@ else
 	wrapdocker > /dev/null 2>&1 &
 	sleep 10
 	echo "=> Checking docker daemon"
-	docker version > /dev/null 2>&1 || (echo "   Failed to start docker (did you use --privileged when running this container?)" && exit 1)
+	docker version > /dev/null 2>&1 || { echo "   Failed to start docker (did you use --privileged when running this container?)" && exit 1; }
 fi
 
 echo "=> Loading docker auth configuration"


### PR DESCRIPTION
`( .... && exit 1 )` creates a new shell, and `exit 1` only exits the new shell

The `build.sh` exits is not because `exit 1` but `( .... && exit 1)` returns 1, and `set -e` ends the script.
