### PR TITLE
Put DOCKERCFG in proper file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ And then run your builds as above appending `--volumes-from builder_cache` to th
 
 ## Adding repository credentials
 
-If your tests depend on private images, you can pass their credentials either by mounting your local `.docker` folder inside the container appending `-v $HOME/.docker:/.docker:ro`, or by providing the contents of the `.docker/config.json` file via an environment variable called `$DOCKERCFG`: `-e DOCKERCFG=$(cat $HOME/.docker/config.json)`
+If your tests depend on private images, you can pass their credentials either by mounting your local `.docker` folder inside the container appending `-v $HOME/.docker:/.docker:ro`, or by providing the contents of the docker configuration file `$HOME/.docker/config.json` via an environment variable called `$DOCKER_CONFIG`. eg `-e DOCKER_CONFIG="$(cat $HOME/.docker/config.json)"`
 
 ## Using the host docker daemon instead of docker-in-docker
 

--- a/build.sh
+++ b/build.sh
@@ -33,12 +33,17 @@ elif [ ! -z "$DOCKERCFG" ]; then
 	print_msg "   Detected configuration in \$DOCKERCFG"
 	echo "$DOCKERCFG" > /root/.dockercfg
 	unset DOCKERCFG
+elif [ ! -z "$DOCKER_CONFIG" ]; then
+	print_msg "   Detected configuration in \$DOCKER_CONFIG"
+	mkdir -p /root/.docker
+	echo "$DOCKER_CONFIG" > /root/.docker/config.json
+	unset DOCKER_CONFIG
 elif [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
 	REGISTRY=$(echo $IMAGE_NAME | tr "/" "\n" | head -n1 | grep "\." || true)
 	print_msg "   Logging into registry using $USERNAME"
 	docker login -u $USERNAME -p $PASSWORD -e ${EMAIL-no-email@test.com} $REGISTRY
 else
-	print_msg "   WARNING: no \$USERNAME/\$PASSWORD or \$DOCKERCFG found - unable to load any credentials for pushing/pulling"
+	print_msg "   WARNING: no \$USERNAME/\$PASSWORD or \$DOCKERCFG or \$DOCKER_CONFIG found - unable to load any credentials for pushing/pulling"
 fi
 
 #
@@ -155,7 +160,7 @@ TEST=${TEST:-"Tests passed in $(($DATE_DIFF / 60)) minutes and $(($DATE_DIFF % 6
 #
 START_DATE=$(date +"%s")
 if [ ! -z "$IMAGE_NAME" ]; then
-	if [ ! -z "$USERNAME" ] || [ -f /root/.dockercfg ]; then
+	if [ ! -z "$USERNAME" ] || [ -f /root/.dockercfg ] || [ -f /root/.docker/config.json ]; then
 		print_msg "=> Pushing image $IMAGE_NAME"
 		run_hook pre_push
 		if [ -f "hooks/push" ]; then


### PR DESCRIPTION
I don't know if it's docker version changed or something else. Put $HOME/.docker/config.json in /root/.dockercfg does not work for me (And it does not make any sense)
So I put it in /root/.docker/config.json and it works.
Also without double quote, the command line simply was broken by the output of 'cat', so I added it to README.md
