### PR TITLE
Add build argument GIT_BRANCH to docker build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,7 @@ run_hook pre_build
 if [ -f "hooks/build" ]; then
 	run_hook build
 else
-	docker build --rm --force-rm -t this .
+	docker build --rm --force-rm --build-arg GIT_TAG=$GIT_TAG -t this .
 fi
 run_hook post_build
 END_DATE=$(date +"%s")

--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,7 @@ run_hook pre_build
 if [ -f "hooks/build" ]; then
 	run_hook build
 else
-	docker build --rm --force-rm --build-arg GIT_TAG=$GIT_TAG -t this .
+	docker build --rm --force-rm --build-arg GIT_BRANCH=$GIT_BRANCH -t this .
 fi
 run_hook post_build
 END_DATE=$(date +"%s")


### PR DESCRIPTION
This way we can handle different RUN commands on our Dockerfile depending on the tag currently built (production, dev, etc)
Based on this comment: https://github.com/docker/docker/issues/6822#issuecomment-168170031

Usage example on Dockerfile:

```
ARG GIT_BRANCH=develop
ENV GIT_BRANCH ${GIT_BRANCH}
RUN if [ "$GIT_BRANCH" = "master" ]; then grunt init-prod; else grunt init-dev; fi
```
