### PR TITLE
Configure the Dockerfile used via $DOCKERFILE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ VOLUME /var/lib/docker
 RUN mkdir -p ~/.ssh && ssh-keyscan -H github.com | tee -a ~/.ssh/known_hosts
 
 ENV GIT_CLONE_OPTS="--recursive"
+ENV DOCKERFILE="Dockerfile"
 
 ADD version_list /
 ADD *.sh /

--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,7 @@ run_hook pre_build
 if [ -f "hooks/build" ]; then
 	run_hook build
 else
-	docker build --rm --force-rm -t this .
+	docker build -f $DOCKERFILE --rm --force-rm -t this .
 fi
 run_hook post_build
 END_DATE=$(date +"%s")

--- a/build.sh
+++ b/build.sh
@@ -93,9 +93,9 @@ cd /src${DOCKERFILE_PATH:-/}
 if [ -d "hooks" ]; then
 	chmod +x hooks/*
 fi
-if [ ! -f Dockerfile ]; then
+if [ ! -f $DOCKERFILE ]; then
 	print_msg "   WARNING: no Dockerfile detected! Created one using tutum/buildstep"
-	echo "FROM tutum/buildstep" >> Dockerfile
+	echo "FROM tutum/buildstep" >> $DOCKERFILE
 fi
 
 #


### PR DESCRIPTION
We have a few repos we build using an alternate dockerfile. We use a build hook like this one:

``` bash
#!/bin/bash
set -e

if [ -z "$DOCKERFILE" ]; then
    DOCKERFILE="Dockerfile"
fi

docker build -f $DOCKERFILE --rm --force-rm -t this .
```

It would be nice to be able to specify the dockerfile to use via an environment variable.
